### PR TITLE
chore: fix panic on formatting {min,hour,day}s

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -168,7 +168,7 @@ export interface ETHSelectedOptionState {
 export function convertTo(
   selectedEthFormatOption: ETHSelectedOptionState,
   value: any
-) {
+): string {
   if (!selectedEthFormatOption?.value) {
     return "";
   }
@@ -185,13 +185,13 @@ export function convertTo(
     case "Unix Time":
       return convertUnixSecondsToGMT(Number(value));
     case "Bps ↔️ %":
-      return `${((parseFloat(value) * 1_00) / 10_000).toFixed(2).toString()}%`;
+      return `${((parseFloat(value) * 1_00) / 10_000).toFixed(2)}%`;
     case "Days":
-      return value / 86400;
+      return (value / 86400).toString();
     case "Hours":
-      return value / 3600;
+      return (value / 3600).toString();
     case "Minutes":
-      return value / 60;
+      return (value / 60).toString();
     default:
       return "";
   }


### PR DESCRIPTION
[`formatWithCommas`](https://github.com/swiss-knife-xyz/swiss-knife/blob/8c6e3598557d8f4bbe3d21bfeac727d3dc72e022/components/decodedParams/UintParam.tsx#L16-L20 ) expects a string input  but receives a number from `convertTo` when selection option is of type mins/days/hours and hence the app panics when trying to format a uint on these values.
https://github.com/swiss-knife-xyz/swiss-knife/blob/8c6e3598557d8f4bbe3d21bfeac727d3dc72e022/utils/index.ts#L189-L194

to reproduce: https://calldata.swiss-knife.xyz/decoder?calldata=0xf82c50f10000000000000000000000000000000000000000000000000000000000000de3
click on `minutes/days/hours` followed by `format` - the app crashes