### PR TITLE
Add Frame Wallet to Wall of Shame

### DIFF
--- a/app/7702beat/page.tsx
+++ b/app/7702beat/page.tsx
@@ -464,6 +464,13 @@ const shameWallets: SupportedApp[] = [
     supportedChainIds: [], // Empty since they don't support 7702
     twitterHandle: "rainbowdotme",
   },
+  {
+    name: "Frame Wallet",
+    logoUrl: getFaviconUrl("https://frame.sh/"),
+    siteUrl: "https://frame.sh/",
+    supportedChainIds: [], // Empty since they don't support 7702
+    twitterHandle: "0xframe",
+  },
 ];
 
 const shameDapps: SupportedApp[] = [


### PR DESCRIPTION
## Summary
Added Frame Wallet to the Wall of Shame section as it does not currently support EIP-7702 transaction delegation.

## Changes
- Added Frame Wallet to the `shameWallets` array
- Included official website URL (https://frame.sh/)
- Added Twitter handle `@0xframe` for the "Post on X" functionality

## Context
Frame Wallet is a popular Ethereum wallet that would benefit from EIP-7702 support to improve user experience with transaction batching and delegation features.

This addition helps track wallets that still need to implement this important feature and provides a way for users to request support via social media.