### PR TITLE
Feat: added Fundable to 7702Beat

### DIFF
--- a/app/7702beat/page.tsx
+++ b/app/7702beat/page.tsx
@@ -467,6 +467,12 @@ const dapps: SupportedApp[] = [
     siteUrl: "https://www.zamm.finance/",
     supportedChainIds: [mainnet.id],
   },
+  {
+    name: "Fundable Finance",
+    logoUrl: getFaviconUrl("https://evm.fundable.finance"),
+    siteUrl: "https://evm.fundable.finance",
+    supportedChainIds: [base.id, bsc.id, arbitrum.id]
+  }
 ];
 
 // Wall of Shame data


### PR DESCRIPTION
Added Fundable to 7702Beat. Fundable allows users to distribute tokens to multiple recipients in a single transaction.