### PR TITLE
fix: URI_TOO_LONG issue on wallet signature

### DIFF
--- a/app/wallet/signatures/components/WalletSignatures.tsx
+++ b/app/wallet/signatures/components/WalletSignatures.tsx
@@ -199,6 +199,16 @@ export default function WalletSignatures() {
         const jsonString = JSON.stringify(payloadForUrl);
         const base64String = btoa(jsonString);
         const encodedPayload = encodeURIComponent(base64String);
+        
+        let payloadParam = encodedPayload;
+        
+        // If URL would be too long, use sessionStorage, vercel caps the uri size at 14KB
+        // https://vercel.com/docs/errors/URL_TOO_LONG
+        if (encodedPayload.length > 4000) {
+          const storageKey = `swissknife_sig_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+          sessionStorage.setItem(storageKey, jsonString);
+          payloadParam = storageKey;
+        }
 
         // Preserve current query parameters for navigation back
         const preservedParams = new URLSearchParams();
@@ -213,11 +223,15 @@ export default function WalletSignatures() {
 
         let viewUrl = `${getPath(
           subdomains.WALLET.base
-        )}signatures/view?payload=${encodedPayload}`;
+        )}signatures/view?payload=${payloadParam}`;
         if (preservedParams.toString()) {
-          viewUrl += `&returnParams=${encodeURIComponent(
-            preservedParams.toString()
-          )}`;
+          let returnParam = preservedParams.toString();
+          if (returnParam.length > 1500) {
+            const returnKey = `swissknife_ret_${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+            sessionStorage.setItem(returnKey, JSON.stringify({ returnParams: returnParam }));
+            returnParam = returnKey;
+          }
+          viewUrl += `&returnParams=${encodeURIComponent(returnParam)}`;
         }
 
         router.push(viewUrl);

--- a/app/wallet/signatures/components/WalletSignatures.tsx
+++ b/app/wallet/signatures/components/WalletSignatures.tsx
@@ -226,7 +226,7 @@ export default function WalletSignatures() {
         )}signatures/view?payload=${payloadParam}`;
         if (preservedParams.toString()) {
           let returnParam = preservedParams.toString();
-          if (returnParam.length > 1500) {
+          if (returnParam.length > 4000) {
             const returnKey = `swissknife_ret_${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
             sessionStorage.setItem(returnKey, JSON.stringify({ returnParams: returnParam }));
             returnParam = returnKey;

--- a/app/wallet/signatures/view/page.tsx
+++ b/app/wallet/signatures/view/page.tsx
@@ -47,6 +47,16 @@ const decodeDataFromUrl = (
   encodedData: string
 ): SharedSignaturePayload | null => {
   try {
+    // Check if it's a storage key (shorter string starting with 'swissknife_sig_' or 'swissknife_ret_' for signature/returndata)
+    if (encodedData.startsWith('swissknife_sig_') || encodedData.startsWith('swissknife_ret_')) {
+      const storedData = sessionStorage.getItem(encodedData);
+      if (storedData) {
+        return JSON.parse(storedData) as SharedSignaturePayload;
+      }
+      return null;
+    }
+    
+    // Fall back to original URL decoding for backward compatibility
     const base64String = decodeURIComponent(encodedData);
     const jsonString = atob(base64String);
     return JSON.parse(jsonString) as SharedSignaturePayload;
@@ -86,9 +96,9 @@ export default function SignatureView() {
   const [isVerifyingAll, setIsVerifyingAll] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-
   useEffect(() => {
     const encodedData = searchParams.get("payload");
+    const returnParamsData = searchParams.get("returnParams");
     if (encodedData) {
       const decoded = decodeDataFromUrl(encodedData);
       if (decoded && decoded.signers && Array.isArray(decoded.signers)) {
@@ -99,6 +109,14 @@ export default function SignatureView() {
       }
     } else {
       setError("No signature data found in URL.");
+    }
+    if (returnParamsData) {
+      const decodedReturnParams = decodeDataFromUrl(returnParamsData);
+      if (decodedReturnParams) {
+        console.log("Decoded return params:", decodedReturnParams);
+      } else {
+        console.error("Failed to decode return parameters.");
+      }
     }
     setIsLoading(false);
   }, [searchParams]);
@@ -220,16 +238,34 @@ export default function SignatureView() {
         setSignatureData(updatedSignatureData); // This will trigger re-verification useEffect
 
         const jsonString = JSON.stringify(updatedSignatureData);
+        
+        // Check payload size - if too large, use sessionStorage
         const base64String = btoa(jsonString);
         const encodedPayload = encodeURIComponent(base64String);
+        
+        let payloadParam = encodedPayload;
+        
+        // If URL would be too long, use sessionStorage, vercel caps the uri size at 14KB
+        // https://vercel.com/docs/errors/URL_TOO_LONG
+        if (encodedPayload.length > 4000) {
+          const storageKey = `swissknife_sig_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+          sessionStorage.setItem(storageKey, jsonString);
+          payloadParam = storageKey;
+        }
 
         // Preserve the returnParams when updating the URL
         const returnParams = searchParams.get("returnParams");
         let newUrl = `${getPath(
           subdomains.WALLET.base
-        )}signatures/view?payload=${encodedPayload}`;
+        )}signatures/view?payload=${payloadParam}`;
         if (returnParams) {
-          newUrl += `&returnParams=${encodeURIComponent(returnParams)}`;
+          let returnParam = returnParams;
+          if (returnParams.length > 4000) {
+            const returnKey = `swissknife_ret_${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+            sessionStorage.setItem(returnKey, JSON.stringify({ returnParams }));
+            returnParam = returnKey;
+          }
+          newUrl += `&returnParams=${encodeURIComponent(returnParam)}`;
         }
 
         router.push(newUrl, {
@@ -257,8 +293,19 @@ export default function SignatureView() {
 
     if (returnParams) {
       try {
-        const decodedParams = decodeURIComponent(returnParams);
-        backUrl += `?${decodedParams}`;
+        // Check if it's a storage key
+        if (returnParams.startsWith('swissknife_ret_')) {
+          const storedData = sessionStorage.getItem(returnParams);
+          if (storedData) {
+            const parsed = JSON.parse(storedData);
+            const decodedParams = parsed.returnParams;
+            backUrl += `?${decodedParams}`;
+          }
+        } else {
+          // Handle regular URL-encoded params
+          const decodedParams = decodeURIComponent(returnParams);
+          backUrl += `?${decodedParams}`;
+        }
       } catch (error) {
         console.error("Error decoding return parameters:", error);
       }


### PR DESCRIPTION
So I've encountered an `414` error when trying to sign a fairly large EIP-712 signature.

```
An error occurred

URI_TOO_LONG

fra1::
```

this is due to Vercel's cap: https://vercel.com/docs/errors/URL_TOO_LONG

I've opted to cap both `payload` and `returnParam` at 4k/4k, as with URI encoding some chars can cost 3 bytes not just 1, so it's a safe cap. (Could also do runtime check ofc)

If length is over 4k, it just adds it to a `sessionStorage` entry instead, so the final url will look something like this:
http://wallet.swiss-knife.xyz/signatures/view?payload=swissknife_sig_1752691868126_o7r46uhfu&returnParams=swissknife_ret_1752691868126_na1zfr9hc2