### PR TITLE
7702Beat: add Sky.money

### DIFF
--- a/app/7702beat/page.tsx
+++ b/app/7702beat/page.tsx
@@ -495,6 +495,18 @@ const dapps: SupportedApp[] = [
     filterSupportsAllChains: true,
   },
   {
+    name: "Sky.money",
+    logoUrl: getFaviconUrl("https://sky.money/"),
+    siteUrl: "https://sky.money/",
+    supportedChainIds: [
+      mainnet.id,
+      arbitrum.id,
+      base.id,
+      optimism.id,
+      unichain.id,
+    ],
+  },
+  {
     name: "Spark",
     logoUrl: getFaviconUrl("https://spark.fi/"),
     siteUrl: "https://spark.fi/",


### PR DESCRIPTION
### What does this PR do?
It adds Sky.money to the list of dApps that support EIP-5792