### PR TITLE
feat: add BANKR LayerZero bridge

### DIFF
--- a/app/api/og/bankr-bridge/route.tsx
+++ b/app/api/og/bankr-bridge/route.tsx
@@ -1,0 +1,162 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "BANKR bridge between Base and Robinhood Chain";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export async function GET(request: Request) {
+  const font = await fetch(
+    new URL("../../../../assets/Poppins-Bold.ttf", import.meta.url)
+  ).then((response) => response.arrayBuffer());
+  const logo = new URL("/logo.png", request.url).toString();
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "54px 62px",
+          color: "#f4f2ec",
+          background: "#080a09",
+          fontFamily: "Poppins",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            backgroundImage:
+              "linear-gradient(rgba(255,255,255,.04) 1px, transparent 1px),linear-gradient(90deg,rgba(255,255,255,.04) 1px,transparent 1px)",
+            backgroundSize: "72px 72px",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            width: 660,
+            height: 660,
+            borderRadius: "50%",
+            top: -390,
+            right: -50,
+            display: "flex",
+            background: "rgba(157,252,174,.17)",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 15,
+              fontSize: 26,
+            }}
+          >
+            <img src={logo} width="44" height="44" alt="" /> ETH.sh
+          </div>
+          <div
+            style={{
+              display: "flex",
+              color: "#9dfcae",
+              border: "1px solid rgba(157,252,174,.3)",
+              padding: "9px 13px",
+              fontSize: 18,
+            }}
+          >
+            LAYERZERO OFT
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            zIndex: 1,
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", width: 700 }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 84,
+                lineHeight: 0.96,
+                letterSpacing: "-.055em",
+              }}
+            >
+              BANKR, now on Robinhood.
+            </div>
+            <div
+              style={{
+                display: "flex",
+                marginTop: 25,
+                color: "#9b9993",
+                fontSize: 25,
+              }}
+            >
+              Bridge both ways through the verified LayerZero route.
+            </div>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+            <div
+              style={{
+                width: 92,
+                height: 92,
+                border: "1px solid rgba(255,255,255,.15)",
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 20,
+              }}
+            >
+              BASE
+            </div>
+            <div
+              style={{
+                display: "flex",
+                width: 70,
+                height: 2,
+                background: "#9dfcae",
+              }}
+            />
+            <div
+              style={{
+                width: 92,
+                height: 92,
+                color: "#081009",
+                background: "#9dfcae",
+                borderRadius: "50%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 35,
+              }}
+            >
+              R
+            </div>
+          </div>
+        </div>
+        <div
+          style={{ display: "flex", color: "#666963", fontSize: 18, zIndex: 1 }}
+        >
+          eth.sh/bankr-bridge · Base ↔ Robinhood Chain
+        </div>
+      </div>
+    ),
+    { ...size, fonts: [{ name: "Poppins", data: font, style: "normal" }] }
+  );
+}

--- a/app/bankr-bridge/layout.tsx
+++ b/app/bankr-bridge/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { getMetadata } from "@/utils";
+
+export const metadata: Metadata = getMetadata({
+  title: "BANKR Bridge | Base ↔ Robinhood",
+  description:
+    "Bridge BANKR between Base and Robinhood Chain through the official LayerZero OFT route.",
+  images: "https://eth.sh/api/og/bankr-bridge",
+});
+
+export default function BankrBridgeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/bankr-bridge/page.tsx
+++ b/app/bankr-bridge/page.tsx
@@ -1,0 +1,571 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ConnectButton } from "@/components/ConnectButton";
+import {
+  useAccount,
+  usePublicClient,
+  useReadContract,
+  useSwitchChain,
+  useWalletClient,
+} from "wagmi";
+import {
+  formatEther,
+  formatUnits,
+  isAddress,
+  padHex,
+  parseUnits,
+  type Address,
+  type Hex,
+} from "viem";
+import { base } from "viem/chains";
+import { robinhood } from "@/data/common";
+import styles from "./styles.module.css";
+
+const BASE_CHAIN_ID = 8453;
+const BASE_EID = 30184;
+const ROBINHOOD_CHAIN_ID = 4663;
+const ROBINHOOD_EID = 30416;
+const TOKEN = "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b" as Address;
+const ADAPTER = "0xe4bbb2d00aac984ccca26ac5abafd7de3afab8bf" as Address;
+const ROBINHOOD_OFT = "0x178e54df3d091ee4d0b2534742ef9e3692b76526" as Address;
+const EXTRA_OPTIONS = "0x00030100110100000000000000000000000000030d40" as Hex;
+const SHARED_DECIMAL_DUST = 10n ** 12n;
+
+const routes = {
+  toRobinhood: {
+    sourceName: "Base",
+    sourceShortName: "BASE",
+    destinationName: "Robinhood",
+    destinationShortName: "R",
+    chainId: BASE_CHAIN_ID,
+    chain: base,
+    token: TOKEN,
+    oft: ADAPTER,
+    dstEid: ROBINHOOD_EID,
+  },
+  toBase: {
+    sourceName: "Robinhood",
+    sourceShortName: "R",
+    destinationName: "Base",
+    destinationShortName: "BASE",
+    chainId: ROBINHOOD_CHAIN_ID,
+    chain: robinhood,
+    token: ROBINHOOD_OFT,
+    oft: ROBINHOOD_OFT,
+    dstEid: BASE_EID,
+  },
+} as const;
+
+const erc20Abi = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "account", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "allowance",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const sendParamComponents = [
+  { name: "dstEid", type: "uint32" },
+  { name: "to", type: "bytes32" },
+  { name: "amountLD", type: "uint256" },
+  { name: "minAmountLD", type: "uint256" },
+  { name: "extraOptions", type: "bytes" },
+  { name: "composeMsg", type: "bytes" },
+  { name: "oftCmd", type: "bytes" },
+] as const;
+
+const oftAbi = [
+  {
+    type: "function",
+    name: "quoteSend",
+    stateMutability: "view",
+    inputs: [
+      { name: "sendParam", type: "tuple", components: sendParamComponents },
+      { name: "payInLzToken", type: "bool" },
+    ],
+    outputs: [
+      {
+        name: "msgFee",
+        type: "tuple",
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" },
+        ],
+      },
+    ],
+  },
+  {
+    type: "function",
+    name: "send",
+    stateMutability: "payable",
+    inputs: [
+      { name: "sendParam", type: "tuple", components: sendParamComponents },
+      {
+        name: "fee",
+        type: "tuple",
+        components: [
+          { name: "nativeFee", type: "uint256" },
+          { name: "lzTokenFee", type: "uint256" },
+        ],
+      },
+      { name: "refundAddress", type: "address" },
+    ],
+    outputs: [
+      {
+        name: "msgReceipt",
+        type: "tuple",
+        components: [
+          { name: "guid", type: "bytes32" },
+          { name: "nonce", type: "uint64" },
+          {
+            name: "fee",
+            type: "tuple",
+            components: [
+              { name: "nativeFee", type: "uint256" },
+              { name: "lzTokenFee", type: "uint256" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "oftReceipt",
+        type: "tuple",
+        components: [
+          { name: "amountSentLD", type: "uint256" },
+          { name: "amountReceivedLD", type: "uint256" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+type SendParam = {
+  dstEid: number;
+  to: Hex;
+  amountLD: bigint;
+  minAmountLD: bigint;
+  extraOptions: Hex;
+  composeMsg: Hex;
+  oftCmd: Hex;
+};
+
+const shortAddress = (value: string) =>
+  `${value.slice(0, 6)}…${value.slice(-4)}`;
+
+const cleanError = (error: unknown) => {
+  if (!(error instanceof Error)) return "Something went wrong.";
+  if (error.message.includes("User rejected")) return "Transaction rejected.";
+  if (error.message.includes("insufficient funds"))
+    return "Not enough ETH on the source chain to pay the LayerZero fee.";
+  return error.message
+    .split("\n")[0]
+    .replace("ContractFunctionExecutionError: ", "");
+};
+
+export default function BankrBridgePage() {
+  const [direction, setDirection] =
+    useState<keyof typeof routes>("toRobinhood");
+  const route = routes[direction];
+  const isToRobinhood = direction === "toRobinhood";
+  const { address, chainId, isConnected } = useAccount();
+  const { data: walletClient } = useWalletClient();
+  const publicClient = usePublicClient({ chainId: route.chainId });
+  const { switchChainAsync } = useSwitchChain();
+  const [amount, setAmount] = useState("");
+  const [recipient, setRecipient] = useState("");
+  const [fee, setFee] = useState<bigint | null>(null);
+  const [status, setStatus] = useState<
+    "idle" | "quoting" | "approving" | "sending" | "submitted"
+  >("idle");
+  const [error, setError] = useState("");
+  const [txHash, setTxHash] = useState<Hex | null>(null);
+
+  const destination = recipient || address || "";
+  const amountLD = useMemo(() => {
+    try {
+      return amount ? parseUnits(amount, 18) : 0n;
+    } catch {
+      return 0n;
+    }
+  }, [amount]);
+  const minAmountLD = amountLD - (amountLD % SHARED_DECIMAL_DUST);
+
+  const { data: balance } = useReadContract({
+    address: route.token,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: address ? [address] : undefined,
+    chainId: route.chainId,
+    query: { enabled: Boolean(address) },
+  });
+  const { data: allowance, refetch: refetchAllowance } = useReadContract({
+    address: TOKEN,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: address ? [address, ADAPTER] : undefined,
+    chainId: BASE_CHAIN_ID,
+    query: { enabled: Boolean(address) && isToRobinhood },
+  });
+
+  const needsApproval =
+    isToRobinhood && amountLD > 0n && (allowance ?? 0n) < amountLD;
+  const amountIsValid =
+    amountLD > 0n &&
+    minAmountLD > 0n &&
+    amountLD <= (balance ?? 0n) &&
+    isAddress(destination);
+
+  const buildSendParam = (): SendParam => ({
+    dstEid: route.dstEid,
+    to: padHex(destination as Address, { size: 32 }),
+    amountLD,
+    minAmountLD,
+    extraOptions: EXTRA_OPTIONS,
+    composeMsg: "0x",
+    oftCmd: "0x",
+  });
+
+  const resetQuote = () => {
+    setFee(null);
+    setTxHash(null);
+    setStatus("idle");
+    setError("");
+  };
+
+  const quote = async () => {
+    if (!publicClient || !amountIsValid) return;
+    setStatus("quoting");
+    setError("");
+    try {
+      const result = await publicClient.readContract({
+        address: route.oft,
+        abi: oftAbi,
+        functionName: "quoteSend",
+        args: [buildSendParam(), false],
+      });
+      setFee(result.nativeFee);
+      setStatus("idle");
+    } catch (quoteError) {
+      setStatus("idle");
+      setError(cleanError(quoteError));
+    }
+  };
+
+  const approve = async () => {
+    if (!isToRobinhood || !walletClient || !publicClient || !address) return;
+    setStatus("approving");
+    setError("");
+    try {
+      if (chainId !== route.chainId) {
+        await switchChainAsync({ chainId: route.chainId });
+      }
+      const hash = await walletClient.writeContract({
+        account: address,
+        chain: base,
+        address: TOKEN,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [ADAPTER, amountLD],
+      });
+      await publicClient.waitForTransactionReceipt({ hash });
+      await refetchAllowance();
+      setStatus("idle");
+    } catch (approveError) {
+      setStatus("idle");
+      setError(cleanError(approveError));
+    }
+  };
+
+  const send = async () => {
+    if (!walletClient || !publicClient || !address || fee === null) return;
+    setStatus("sending");
+    setError("");
+    try {
+      if (chainId !== route.chainId) {
+        await switchChainAsync({ chainId: route.chainId });
+      }
+      const latestFee = await publicClient.readContract({
+        address: route.oft,
+        abi: oftAbi,
+        functionName: "quoteSend",
+        args: [buildSendParam(), false],
+      });
+      setFee(latestFee.nativeFee);
+      const hash = await walletClient.writeContract({
+        account: address,
+        chain: route.chain,
+        address: route.oft,
+        abi: oftAbi,
+        functionName: "send",
+        args: [
+          buildSendParam(),
+          { nativeFee: latestFee.nativeFee, lzTokenFee: 0n },
+          address,
+        ],
+        value: latestFee.nativeFee,
+      });
+      setTxHash(hash);
+      setStatus("submitted");
+    } catch (sendError) {
+      setStatus("idle");
+      setError(cleanError(sendError));
+    }
+  };
+
+  const buttonLabel =
+    status === "quoting"
+      ? "Getting live quote…"
+      : status === "approving"
+        ? "Approving BANKR…"
+        : status === "sending"
+          ? "Confirming bridge…"
+          : fee === null
+            ? "Review bridge"
+            : needsApproval
+              ? "Approve BANKR"
+              : `Bridge to ${route.destinationName}`;
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.ambient} aria-hidden="true" />
+      <nav className={styles.nav}>
+        <a className={styles.brand} href="/">
+          <span className={styles.brandMark}>Ξ</span>
+          <span>ETH.sh</span>
+        </a>
+        <ConnectButton expectedChainId={route.chainId} />
+      </nav>
+
+      <section className={styles.shell}>
+        <header className={styles.intro}>
+          <div className={styles.eyebrow}>
+            <span className={styles.liveDot} /> LayerZero OFT route
+          </div>
+          <h1>
+            BANKR, across
+            <span> both worlds.</span>
+          </h1>
+          <p>
+            Move BANKR between Base and Robinhood Chain through the verified OFT
+            route. Switch direction without leaving the bridge.
+          </p>
+          <div className={styles.routeLine}>
+            <div>
+              <b>{route.sourceShortName}</b>
+              <small>{route.sourceName}</small>
+            </div>
+            <span>
+              <i />
+              <em>LayerZero</em>
+              <i />
+            </span>
+            <div>
+              <b>{route.destinationShortName}</b>
+              <small>{route.destinationName}</small>
+            </div>
+          </div>
+        </header>
+
+        <div className={styles.card}>
+          <div className={styles.cardHead}>
+            <div>
+              <span>BRIDGE</span>
+              <strong>
+                {route.sourceName} → {route.destinationName}
+              </strong>
+            </div>
+            <div className={styles.cardActions}>
+              <div className={styles.eta}>~90 sec</div>
+              <button
+                className={styles.flipButton}
+                type="button"
+                onClick={() => {
+                  setDirection((current) =>
+                    current === "toRobinhood" ? "toBase" : "toRobinhood"
+                  );
+                  setAmount("");
+                  setRecipient("");
+                  resetQuote();
+                }}
+                aria-label="Reverse bridge direction"
+                title="Reverse bridge direction"
+              >
+                ⇄
+              </button>
+            </div>
+          </div>
+
+          <label className={styles.fieldLabel} htmlFor="amount">
+            You send
+            <button
+              type="button"
+              onClick={() => {
+                if (balance !== undefined) {
+                  setAmount(formatUnits(balance, 18));
+                  resetQuote();
+                }
+              }}
+            >
+              Balance{" "}
+              {balance === undefined
+                ? "—"
+                : Number(formatUnits(balance, 18)).toLocaleString(undefined, {
+                    maximumFractionDigits: 2,
+                  })}
+            </button>
+          </label>
+          <div className={styles.amountBox}>
+            <input
+              id="amount"
+              inputMode="decimal"
+              value={amount}
+              onChange={(event) => {
+                setAmount(event.target.value.replace(/[^\d.]/g, ""));
+                resetQuote();
+              }}
+              placeholder="0.00"
+              aria-label="BANKR amount"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (balance !== undefined) {
+                  setAmount(formatUnits(balance, 18));
+                  resetQuote();
+                }
+              }}
+            >
+              MAX
+            </button>
+            <div className={styles.tokenPill}>
+              <span>B</span>BANKR
+            </div>
+          </div>
+
+          <label className={styles.fieldLabel} htmlFor="recipient">
+            Recipient on {route.destinationName}
+            <span>Defaults to connected wallet</span>
+          </label>
+          <div className={styles.recipientBox}>
+            <span>0x</span>
+            <input
+              id="recipient"
+              value={recipient}
+              onChange={(event) => {
+                setRecipient(event.target.value.trim());
+                resetQuote();
+              }}
+              placeholder={address ? shortAddress(address) : "Wallet address"}
+              aria-invalid={Boolean(recipient) && !isAddress(recipient)}
+            />
+          </div>
+
+          <div className={styles.summary}>
+            <div>
+              <span>Route</span>
+              <b>
+                {isToRobinhood
+                  ? "OFT Adapter → Native OFT"
+                  : "Native OFT → OFT Adapter"}
+              </b>
+            </div>
+            <div>
+              <span>LayerZero fee</span>
+              <b>
+                {fee === null
+                  ? "Live quote"
+                  : `${Number(formatEther(fee)).toFixed(6)} ETH`}
+              </b>
+            </div>
+            <div>
+              <span>You receive</span>
+              <b>
+                {minAmountLD ? `${formatUnits(minAmountLD, 18)} BANKR` : "—"}
+              </b>
+            </div>
+          </div>
+
+          {error ? <div className={styles.error}>{error}</div> : null}
+          {txHash ? (
+            <div className={styles.success}>
+              <div>
+                <span>✓</span>
+                <p>
+                  <b>Bridge submitted</b>
+                  <small>Delivery usually takes about 90 seconds.</small>
+                </p>
+              </div>
+              <a
+                href={`https://layerzeroscan.com/tx/${txHash}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Track on LayerZero Scan ↗
+              </a>
+            </div>
+          ) : null}
+
+          {!isConnected ? (
+            <div className={styles.connectWrap}>
+              <ConnectButton expectedChainId={route.chainId} hideChain />
+            </div>
+          ) : (
+            <button
+              className={styles.primaryButton}
+              type="button"
+              disabled={!amountIsValid || status !== "idle"}
+              onClick={fee === null ? quote : needsApproval ? approve : send}
+            >
+              {buttonLabel}
+              <span>→</span>
+            </button>
+          )}
+
+          <p className={styles.disclaimer}>
+            Permissionless LayerZero route · 2 DVNs · 20 confirmations
+          </p>
+        </div>
+      </section>
+
+      <footer className={styles.footer}>
+        <a
+          href={`https://basescan.org/address/${ADAPTER}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Base adapter {shortAddress(ADAPTER)} ↗
+        </a>
+        <a
+          href={`https://robinhoodchain.blockscout.com/address/${ROBINHOOD_OFT}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Robinhood OFT {shortAddress(ROBINHOOD_OFT)} ↗
+        </a>
+      </footer>
+    </main>
+  );
+}

--- a/app/bankr-bridge/styles.module.css
+++ b/app/bankr-bridge/styles.module.css
@@ -1,0 +1,549 @@
+.page {
+  --ink: #f4f2ec;
+  --muted: #9b9993;
+  --line: rgba(255, 255, 255, 0.11);
+  --green: #9dfcae;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  color: var(--ink);
+  background: #080a09;
+  font-family: var(--font-inter), sans-serif;
+}
+
+.page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.26;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(to bottom, black, transparent 84%);
+}
+
+.ambient {
+  position: absolute;
+  width: 720px;
+  height: 720px;
+  top: -420px;
+  right: -100px;
+  border-radius: 50%;
+  background: #6bff88;
+  filter: blur(140px);
+  opacity: 0.09;
+  pointer-events: none;
+}
+
+.nav,
+.footer {
+  width: min(1180px, calc(100% - 48px));
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.nav {
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 720;
+  letter-spacing: -0.03em;
+  font-size: 19px;
+}
+.brandMark {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  background: #111411;
+  border-radius: 50%;
+  color: var(--green);
+  font-size: 18px;
+}
+
+.shell {
+  width: min(1080px, calc(100% - 48px));
+  min-height: calc(100vh - 165px);
+  margin: 0 auto;
+  padding: 78px 0 62px;
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1fr 470px;
+  align-items: center;
+  gap: 92px;
+}
+
+.intro {
+  animation: rise 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: #c7c6c0;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+.liveDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow:
+    0 0 0 5px rgba(157, 252, 174, 0.08),
+    0 0 20px rgba(157, 252, 174, 0.42);
+}
+.intro h1 {
+  max-width: 570px;
+  margin: 27px 0 24px;
+  font-size: clamp(52px, 6.1vw, 84px);
+  line-height: 0.93;
+  letter-spacing: -0.07em;
+  font-weight: 670;
+}
+.intro h1 span {
+  color: var(--green);
+}
+.intro > p {
+  max-width: 510px;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.routeLine {
+  display: flex;
+  align-items: center;
+  margin-top: 60px;
+  gap: 15px;
+}
+.routeLine > div {
+  width: 70px;
+  height: 70px;
+  flex: 0 0 70px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.025);
+}
+.routeLine b {
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+.routeLine small {
+  color: #73756f;
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.routeLine > span {
+  width: 170px;
+  display: flex;
+  align-items: center;
+  color: #686a65;
+}
+.routeLine i {
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, var(--line), rgba(157, 252, 174, 0.55));
+}
+.routeLine i:last-child {
+  background: linear-gradient(90deg, rgba(157, 252, 174, 0.55), var(--line));
+}
+.routeLine em {
+  padding: 0 9px;
+  font-style: normal;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.card {
+  background: rgba(17, 19, 17, 0.91);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 3px;
+  padding: 28px;
+  box-shadow: 0 38px 100px rgba(0, 0, 0, 0.42);
+  animation: rise 0.6s 0.1s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  backdrop-filter: blur(20px);
+}
+.cardHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 24px;
+}
+.cardHead > div:first-child {
+  display: grid;
+  gap: 5px;
+}
+.cardHead span,
+.fieldLabel {
+  color: #777a74;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+.cardHead strong {
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+.eta {
+  padding: 6px 9px;
+  color: var(--green);
+  border: 1px solid rgba(157, 252, 174, 0.22);
+  background: rgba(157, 252, 174, 0.06);
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.flipButton {
+  width: 29px;
+  height: 29px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  color: var(--ink);
+  background: #0b0d0b;
+  font-size: 16px;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s,
+    transform 0.2s;
+}
+
+.flipButton:hover {
+  color: var(--green);
+  border-color: rgba(157, 252, 174, 0.45);
+  transform: rotate(180deg);
+}
+
+.fieldLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 18px 0 10px;
+}
+.fieldLabel button,
+.fieldLabel span {
+  border: 0;
+  background: none;
+  color: #858780;
+  font: inherit;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.amountBox,
+.recipientBox {
+  display: flex;
+  align-items: center;
+  min-height: 76px;
+  border: 1px solid var(--line);
+  background: #0b0d0b;
+  transition: border-color 0.2s;
+}
+.amountBox:focus-within,
+.recipientBox:focus-within {
+  border-color: rgba(157, 252, 174, 0.52);
+}
+.amountBox input,
+.recipientBox input {
+  min-width: 0;
+  flex: 1;
+  color: var(--ink);
+  background: transparent;
+  border: 0;
+  outline: 0;
+}
+.amountBox input {
+  padding: 0 8px 0 18px;
+  font-size: 31px;
+  font-weight: 580;
+  letter-spacing: -0.04em;
+}
+.amountBox input::placeholder,
+.recipientBox input::placeholder {
+  color: #444741;
+}
+.amountBox > button {
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  color: #8c8f87;
+  background: #111411;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 9px;
+  cursor: pointer;
+}
+.tokenPill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 14px;
+  font-size: 12px;
+  font-weight: 700;
+}
+.tokenPill span {
+  width: 27px;
+  height: 27px;
+  display: grid;
+  place-items: center;
+  color: #071008;
+  background: var(--green);
+  border-radius: 50%;
+  font-size: 13px;
+}
+.recipientBox {
+  min-height: 51px;
+  padding: 0 15px;
+}
+.recipientBox > span {
+  color: #5c5e59;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+}
+.recipientBox input {
+  padding: 0 8px;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 11px;
+}
+
+.summary {
+  display: grid;
+  gap: 10px;
+  margin: 22px 0;
+  padding: 17px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+.summary div {
+  display: flex;
+  justify-content: space-between;
+  gap: 15px;
+  font-size: 11px;
+}
+.summary span {
+  color: #777a74;
+}
+.summary b {
+  font-weight: 520;
+  text-align: right;
+}
+.primaryButton {
+  width: 100%;
+  height: 57px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+  color: #071008;
+  background: var(--green);
+  border: 0;
+  font-weight: 760;
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    background 0.2s;
+}
+.primaryButton:hover:not(:disabled) {
+  transform: translateY(-2px);
+  background: #bbffc6;
+}
+.primaryButton:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+.primaryButton span {
+  font-size: 19px;
+}
+.connectWrap {
+  min-height: 57px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(157, 252, 174, 0.3);
+  background: rgba(157, 252, 174, 0.06);
+}
+.error {
+  margin: -8px 0 16px;
+  padding: 10px 12px;
+  border-left: 2px solid #ff746c;
+  color: #ffaaa5;
+  background: rgba(255, 80, 70, 0.08);
+  font-size: 11px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.success {
+  margin: -8px 0 16px;
+  padding: 13px;
+  border: 1px solid rgba(157, 252, 174, 0.22);
+  background: rgba(157, 252, 174, 0.06);
+}
+.success > div {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.success > div > span {
+  width: 25px;
+  height: 25px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #071008;
+  background: var(--green);
+}
+.success p {
+  display: grid;
+  margin: 0;
+  gap: 2px;
+  font-size: 11px;
+}
+.success small {
+  color: #92958e;
+}
+.success a {
+  display: inline-block;
+  margin: 11px 0 0 35px;
+  color: var(--green);
+  font-size: 10px;
+}
+.disclaimer {
+  margin: 14px 0 0;
+  text-align: center;
+  color: #585b55;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.footer {
+  height: 75px;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  border-top: 1px solid var(--line);
+}
+.footer a {
+  color: #666963;
+  text-decoration: none;
+  font-family: var(--font-jetbrains-mono), monospace;
+  font-size: 9px;
+}
+.footer a:hover {
+  color: var(--green);
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .shell {
+    grid-template-columns: 1fr;
+    gap: 58px;
+    padding-top: 54px;
+  }
+  .intro {
+    text-align: center;
+  }
+  .intro > p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .eyebrow,
+  .routeLine {
+    justify-content: center;
+  }
+  .card {
+    width: min(100%, 500px);
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .nav,
+  .footer,
+  .shell {
+    width: min(100% - 28px, 1080px);
+  }
+  .nav {
+    height: 76px;
+  }
+  .shell {
+    padding: 45px 0;
+  }
+  .intro h1 {
+    font-size: 49px;
+  }
+  .intro > p {
+    font-size: 15px;
+  }
+  .routeLine {
+    margin-top: 38px;
+  }
+  .card {
+    padding: 20px;
+  }
+  .amountBox input {
+    font-size: 25px;
+  }
+  .footer {
+    height: auto;
+    padding: 22px 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro,
+  .card {
+    animation: none;
+  }
+  .primaryButton {
+    transition: none;
+  }
+}

--- a/data/chains.ts
+++ b/data/chains.ts
@@ -26,12 +26,13 @@ import {
   zora,
   Chain,
 } from "wagmi/chains";
-import { plasma, megaeth, citrea, monad } from "./common";
+import { plasma, megaeth, citrea, monad, robinhood } from "./common";
 
 export const walletChains: readonly [Chain, ...Chain[]] = [
   // first chain is the default
   mainnet,
   base,
+  robinhood,
   arbitrum,
   avalanche,
   bsc,

--- a/data/common.ts
+++ b/data/common.ts
@@ -189,6 +189,22 @@ export const megaeth = defineChain({
   testnet: false,
 });
 
+export const robinhood = defineChain({
+  id: 4663,
+  name: "Robinhood Chain",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://rpc.mainnet.chain.robinhood.com"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Robinhood Chain Explorer",
+      url: "https://robinhoodchain.blockscout.com",
+    },
+  },
+  testnet: false,
+});
+
 export const CHAINLABEL_KEY = "$SK_CHAINLABEL";
 export const ADDRESS_KEY = "$SK_ADDRESS";
 export const TX_KEY = "$SK_TX";
@@ -262,6 +278,7 @@ export const c: { [name: string]: Chain } = {
   optimismGoerli,
   optimismSepolia,
   plasma,
+  robinhood,
   polygon,
   polygonMumbai,
   polygonZkEvm,


### PR DESCRIPTION
## Summary

- add a dedicated BANKR bridge UI at `/bankr-bridge`
- support Base → Robinhood via the OFT adapter, including ERC-20 approval
- support Robinhood → Base via the native OFT burn flow
- add Robinhood Chain to the shared wallet configuration
- add page metadata and a dedicated Open Graph image

## LayerZero safety

- compute shared-decimal dust truncation with bigint
- include the required type-3 receive options
- refresh the native fee quote immediately before sending
- link submitted transactions to LayerZero Scan

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm build`
- live `oftVersion`, `approvalRequired`, `peers`, and `quoteSend` probes in both directions