### PR TITLE
orgs: add Nyx Foundation and a security and formal verification focus area

### DIFF
--- a/app/orgs/data.ts
+++ b/app/orgs/data.ts
@@ -777,6 +777,46 @@ export const ethereumOrgs: EthereumOrg[] = [
       },
     ],
   },
+  {
+    id: "nyx-foundation",
+    name: "Nyx Foundation",
+    shortName: "Nyx",
+    handle: "@NyxFoundation",
+    website: "https://nyx.foundation/en/",
+    twitter: "https://x.com/NyxFoundation",
+    logoDomain: "nyx.foundation",
+    accent: "#D946EF",
+    category: "Security and formal verification",
+    stage: "Established Sep 2025",
+    role: "Vulnerability research and machine-checked proofs across Ethereum clients, protocol specifications, and applications.",
+    summary:
+      "Nyx Foundation is a Tokyo-based non-profit research institute that finds security bugs across the Ethereum stack and proves them away, combining formal verification in Lean 4, cryptography, and AI agents across client implementations, protocol specifications, and DeFi.",
+    evidence: [
+      "Founded in Tokyo in September 2025 by researchers holding Ethereum Foundation research grants; the team has co-authored papers with the EF and works inside its post-quantum migration effort.",
+      "Ranked first worldwide by report count in the Fusaka client audit contest with 17 vulnerabilities, and has audited DeFi and ZK systems including zERC20, Intmax's zkRollup proof library, and SP1 zkVM.",
+      "Funded entirely by donations, research grants, and sponsorships from the Ethereum Foundation, Fenbushi Capital, and the TL;DR Fellowship, with all output released as open source, public vulnerability reports, and machine-checkable formal specifications.",
+    ],
+    workstreams: [
+      "Client and protocol security: specification-driven agents that detect vulnerabilities in client implementations before they ship (SPECA), and a Lean 4-verified consensus client alongside formalization of the leanEthereum specification (Verity).",
+      "Application and market security: audits of DeFi protocols and ZK systems, an experimental L2 that stress-tests live DeFi designs before mainnet (Eris), and empirical research on liquidity provision, JIT liquidity, and MEV.",
+      "Post-quantum and education: formal verification of post-quantum signature schemes for Ethereum's PQ transition, and the Advanced Cryptography Program on ZK, FHE, and MPC, taken over from the Ethereum Foundation in 2025 and co-hosted with the University of Tokyo in 2026.",
+    ],
+    watch: [
+      "Whether formalizing leanEthereum in Lean 4 keeps surfacing specification-level bugs as the spec stabilizes.",
+      "Whether specification-driven auditing produces findings that client and application teams act on before deployment rather than after.",
+      "How the post-quantum verification work lands against Ethereum's PQ migration timeline.",
+    ],
+    sources: [
+      { label: "Official site", href: "https://nyx.foundation/en/" },
+      { label: "Dashboard", href: "https://nyx.foundation/en/dashboard" },
+      { label: "GitHub", href: "https://github.com/NyxFoundation" },
+      { label: "Support", href: "https://nyx.foundation/en/support" },
+      {
+        label: "Advanced Cryptography Program",
+        href: "https://github.com/zk-tokyo/advanced-cryptography-2026",
+      },
+    ],
+  },
 ];
 
 export const ethTreasuryCompanies: EthTreasuryCompany[] = [
@@ -908,6 +948,12 @@ export const roleMap = [
     description:
       "Token-free infrastructure, transparent funding, burn-aligned grants, validator coordination",
     orgIds: ["ethereum-community-foundation"],
+  },
+  {
+    label: "Security and formal verification",
+    description:
+      "Vulnerability research, formal specification, machine-checked proofs across clients and applications",
+    orgIds: ["nyx-foundation"],
   },
 ];
 


### PR DESCRIPTION
## Proposal

Add **Nyx Foundation** to the Ethereum Orgs directory, and add a **Security and formal verification** lane to the focus areas.

## Why a new focus area

The directory currently covers 17 orgs across stewardship, funding, adoption, institutions, policy, and developer tooling. None of them covers security research or formal verification — checking that client implementations and protocol specifications are actually correct.

That is a meaningful gap. Client diversity means the same specification is implemented several times over, and the work of finding where those implementations disagree with the spec (and where the spec itself is wrong) is a distinct lane from the developer-tooling and protocol-R&D entries already listed.

So this PR adds both the org entry and a `roleMap` lane, in the same shape as the `#treasuries` section added in 74eb65d.

## About Nyx Foundation

Tokyo-based non-profit research institute, established September 2025 by researchers holding Ethereum Foundation research grants. Work spans three layers:

- **Clients and protocol** — ranked first worldwide by report count in the Fusaka client audit contest (17 vulnerabilities); formalizing the leanEthereum specification in Lean 4, which surfaced critical bugs in the spec itself; reported vulnerabilities in Nimbus and Erigon, and fixed an RPC bug in Geth
- **Applications** — audits of zERC20, Intmax's zkRollup proof library, SP1 zkVM, and the Current Finance contest
- **Markets and post-quantum** — empirical DeFi research on liquidity provision and JIT liquidity; formal verification of XMSS presented at the EF-hosted PQ Interop workshop at the University of Cambridge

It is funded entirely by donations, research grants, and sponsorships, including from the Ethereum Foundation, Fenbushi Capital, and the TL;DR Fellowship. All output ships as open source, public vulnerability reports, and formal specifications. It also took over the Advanced Cryptography Program from the Ethereum Foundation in 2025; the 2026 edition is co-hosted with the University of Tokyo.

## Notes

- `evidence`, `workstreams`, and `watch` are 3 entries each, matching every existing org
- `watch` is written as forward-looking observation points, matching the existing entries rather than listing past results
- `accent` is `#D946EF`, which does not collide with any existing accent
- `logoDomain` is `nyx.foundation`; the favicon endpoint resolves for it
- Prettier passes on the changed file
- Based on `v2`, since `app/orgs/` only exists there

Happy to adjust the wording, trim the entry, or drop the new lane and file Nyx under an existing one if you would rather keep the focus areas as they are.

## Sources

- Official site: https://nyx.foundation/en/
- Dashboard of outputs and publications: https://nyx.foundation/en/dashboard
- GitHub: https://github.com/NyxFoundation
- leanEthereum formalization: https://github.com/NyxFoundation/formal-leanSpec
- SPECA: https://github.com/NyxFoundation/speca
- Advanced Cryptography Program 2026: https://github.com/zk-tokyo/advanced-cryptography-2026
